### PR TITLE
[BE/fix] 정의되지 않은 enum 값이 올 때에도 통일성 있는 예외 메시지 응답하기

### DIFF
--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/member/adapter/in/CreateMemberController.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/member/adapter/in/CreateMemberController.java
@@ -23,6 +23,9 @@ public class CreateMemberController {
 
     @PostMapping("/members")
     public ApiResponse<?> createMember(@RequestBody CreateMemberRequest request) {
+        if (request.activity() == null) {
+            return ApiResponseGenerator.fail("Invalid activity", HttpStatus.BAD_REQUEST);
+        }
         CreateMemberCommand command = CreateMemberCommand.builder()
                 .height(request.height())
                 .weight(request.weight())

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/member/adapter/in/CreateMemberController.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/member/adapter/in/CreateMemberController.java
@@ -30,6 +30,6 @@ public class CreateMemberController {
                 .age(request.age())
                 .activity(request.activity()).build();
         createMemberUsecase.execute(command);
-        return ApiResponseGenerator.success(HttpStatus.OK);
+        return ApiResponseGenerator.success(HttpStatus.CREATED);
     }
 }

--- a/BE/exceed/src/main/java/com/gaebaljip/exceed/member/domain/Activity.java
+++ b/BE/exceed/src/main/java/com/gaebaljip/exceed/member/domain/Activity.java
@@ -1,6 +1,9 @@
 package com.gaebaljip.exceed.member.domain;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import java.util.Arrays;
 
 public enum Activity {
 
@@ -16,13 +19,20 @@ public enum Activity {
         this.value = value;
     }
 
+    @JsonCreator
+    public static Activity from(String value) {
+        if (value == null)
+            return null;
+        return Arrays.stream(values())
+                .filter(var -> var.name().equals(value))
+                .findAny()
+                .orElse(null);
+    }
+
+    @JsonValue
     public double getValue() {
         return value;
     }
 
-    @JsonCreator
-    public static Activity from(String value) {
-        return Activity.valueOf(value.toUpperCase());
-    }
 
 }

--- a/BE/exceed/src/test/java/com/gaebaljip/exceed/member/adapter/in/CreateMemberControllerTest.java
+++ b/BE/exceed/src/test/java/com/gaebaljip/exceed/member/adapter/in/CreateMemberControllerTest.java
@@ -9,6 +9,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.ResultActions;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(CreateMemberController.class)
@@ -17,24 +18,24 @@ class CreateMemberControllerTest extends CommonApiTest {
     @MockBean
     private CreateMemberUsecase createMemberUsecase;
 
-//    @Test
-//    @DisplayName("회원가입 성공")
-//    void createMember() throws Exception {
-//        //given
-//
-//        CreateMemberTestRequest request = new CreateMemberTestRequest(
-//                171, true, 61, 25, "NOT_ACTIVE", "뭐든 잘 먹습니다.");
-//
-//        //when
-//        ResultActions resultActions = mockMvc.perform(
-//                post("/v1/members")
-//                        .content(om.writeValueAsString(request))
-//                        .contentType(MediaType.APPLICATION_JSON));
-//
-//
-//        //then
-//        resultActions.andExpect(status().isOk());
-//    }
+    @Test
+    @DisplayName("회원가입 성공")
+    void createMember() throws Exception {
+        //given
+
+        CreateMemberTestRequest request = new CreateMemberTestRequest(
+                171, true, 61, 25, "NOT_ACTIVE", "뭐든 잘 먹습니다.");
+
+        //when
+        ResultActions resultActions = mockMvc.perform(
+                post("/v1/members")
+                        .content(om.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON));
+
+
+        //then
+        resultActions.andExpect(status().isCreated());
+    }
 
     @Test
     @DisplayName("유효하지 않은 activity 입력시 오류 발생")
@@ -53,6 +54,7 @@ class CreateMemberControllerTest extends CommonApiTest {
 
         //then
         resultActions.andExpect(status().isBadRequest());
+        resultActions.andExpect(jsonPath("$.error.reason").value("Invalid activity"));
     }
 
 


### PR DESCRIPTION
## 📌 관련 이슈

https://github.com/JNU-econovation/Gaebaljip/issues/25

## 🔑 주요 변경사항

- CreateMemberControllerTest의 createMember 테스트 주석 헤제
- 통일성 있는 메시지 응답하도록 수정