### PR TITLE
[AOS/feat] 바텀 네비게이션 바, 화면 전환

### DIFF
--- a/AOS/app/build.gradle.kts
+++ b/AOS/app/build.gradle.kts
@@ -71,4 +71,9 @@ dependencies {
     //firebase sdk
     implementation(platform("com.google.firebase:firebase-bom:32.7.0"))
     implementation("com.google.firebase:firebase-analytics-ktx")
+
+    //Bottom Navigation sdk
+    implementation("androidx.navigation:navigation-compose:2.5.3")
+    implementation("androidx.compose.material:material:1.4.3")
+    implementation("androidx.compose.material3:material3:1.1.2")
 }

--- a/AOS/app/src/main/java/com/gaebaljip/exceed/BottomNavItem.kt
+++ b/AOS/app/src/main/java/com/gaebaljip/exceed/BottomNavItem.kt
@@ -1,0 +1,33 @@
+package com.gaebaljip.exceed
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AddCircle
+import androidx.compose.material.icons.filled.Home
+import androidx.compose.material.icons.filled.Notifications
+import androidx.compose.ui.graphics.vector.ImageVector
+
+sealed class BottomNavItem(
+    val title: String,
+    val icon: Int,
+    val route: String
+) {
+    object Home : BottomNavItem(
+        "Home", R.drawable.ic_home, "home"
+    )
+
+    object Calendar : BottomNavItem(
+        "Calendar", R.drawable.ic_calendar, "calendar"
+    )
+
+    object Add : BottomNavItem(
+        "Add", R.drawable.ic_add, "add"
+    )
+
+    object Food : BottomNavItem(
+        "Food", R.drawable.ic_food, "food"
+    )
+
+    object Alarm : BottomNavItem(
+        "Alarm", R.drawable.ic_alarm, "alarm"
+    )
+}

--- a/AOS/app/src/main/java/com/gaebaljip/exceed/MainActivity.kt
+++ b/AOS/app/src/main/java/com/gaebaljip/exceed/MainActivity.kt
@@ -3,13 +3,33 @@ package com.gaebaljip.exceed
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.BottomNavigationItem
+import androidx.compose.material.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.currentBackStackEntryAsState
+import androidx.navigation.compose.rememberNavController
+import com.gaebaljip.exceed.screens.AddScreen
+import com.gaebaljip.exceed.screens.AlarmScreen
+import com.gaebaljip.exceed.screens.CalendarScreen
+import com.gaebaljip.exceed.screens.FoodScreen
+import com.gaebaljip.exceed.screens.HomeScreen
 import com.gaebaljip.exceed.ui.theme.ExceedTheme
 
 class MainActivity : ComponentActivity() {
@@ -22,7 +42,7 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    Greeting("Android")
+                    MainScreenView()
                 }
             }
         }
@@ -30,17 +50,87 @@ class MainActivity : ComponentActivity() {
 }
 
 @Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
+fun MainScreenView() {
+    val navController = rememberNavController()
+    Scaffold(bottomBar = {
+        BottomNavigation(navController = navController)
+    }) {
+        Box(Modifier.padding(it)) {
+            NavigationGraph(navController = navController)
+        }
+    }
+}
+
+@Composable
+fun BottomNavigation(navController: NavHostController) {
+    val items = listOf<BottomNavItem>(
+        BottomNavItem.Home,
+        BottomNavItem.Calendar,
+        BottomNavItem.Add,
+        BottomNavItem.Food,
+        BottomNavItem.Alarm
     )
+
+    androidx.compose.material.BottomNavigation(
+        backgroundColor = Color.White,
+        contentColor = Color.Magenta
+    ) {
+        val navBackStackEntry by navController.currentBackStackEntryAsState()
+        val currentRoute = navBackStackEntry?.destination?.route
+
+        items.forEach { item ->
+            BottomNavigationItem(
+                selected = item.route == currentRoute,
+                icon = {
+                    Icon(
+                        painter = painterResource(id = item.icon),
+                        contentDescription = item.title,
+                        modifier = Modifier
+                            .width(32.dp)
+                            .height(32.dp)
+                    )
+                },
+                selectedContentColor = Color(253,166,1,100),
+                unselectedContentColor = Color.Black,
+                onClick = {
+                    navController.navigate(item.route) {
+                        navController.graph.startDestinationRoute?.let {
+                            popUpTo(it) { saveState = true }
+                        }
+                        launchSingleTop = true
+                        restoreState = true
+                    }
+                }
+            )
+        }
+    }
+}
+
+@Composable
+fun NavigationGraph(navController: NavHostController) {
+    NavHost(navController = navController, startDestination = BottomNavItem.Home.route) {
+        composable(BottomNavItem.Home.route) {
+            HomeScreen()
+        }
+        composable(BottomNavItem.Calendar.route) {
+            CalendarScreen()
+        }
+        composable(BottomNavItem.Add.route) {
+            AddScreen()
+        }
+        composable(BottomNavItem.Food.route) {
+            FoodScreen()
+        }
+        composable(BottomNavItem.Alarm.route) {
+            AlarmScreen()
+        }
+    }
 }
 
 @Preview(showBackground = true)
 @Composable
 fun GreetingPreview() {
     ExceedTheme {
-        Greeting("Android")
+        MainScreenView()
     }
 }

--- a/AOS/app/src/main/java/com/gaebaljip/exceed/screens/AddScreen.kt
+++ b/AOS/app/src/main/java/com/gaebaljip/exceed/screens/AddScreen.kt
@@ -1,0 +1,25 @@
+package com.gaebaljip.exceed.screens
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+
+@Composable
+fun AddScreen() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+    ) {
+        Text(
+            text = "Add",
+            style = MaterialTheme.typography.bodyLarge,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.align(Alignment.Center)
+        )
+    }
+}

--- a/AOS/app/src/main/java/com/gaebaljip/exceed/screens/AlarmScreen.kt
+++ b/AOS/app/src/main/java/com/gaebaljip/exceed/screens/AlarmScreen.kt
@@ -1,0 +1,25 @@
+package com.gaebaljip.exceed.screens
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+
+@Composable
+fun AlarmScreen() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+    ) {
+        Text(
+            text = "Alarm",
+            style = MaterialTheme.typography.bodyLarge,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.align(Alignment.Center)
+        )
+    }
+}

--- a/AOS/app/src/main/java/com/gaebaljip/exceed/screens/CalendarScreen.kt
+++ b/AOS/app/src/main/java/com/gaebaljip/exceed/screens/CalendarScreen.kt
@@ -1,0 +1,27 @@
+package com.gaebaljip.exceed.screens
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import com.gaebaljip.exceed.R
+
+@Composable
+fun CalendarScreen() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+    ) {
+        Text(
+            text = "Calendar",
+            style = MaterialTheme.typography.bodyLarge,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.align(Alignment.Center)
+        )
+    }
+}

--- a/AOS/app/src/main/java/com/gaebaljip/exceed/screens/FoodScreen.kt
+++ b/AOS/app/src/main/java/com/gaebaljip/exceed/screens/FoodScreen.kt
@@ -1,0 +1,25 @@
+package com.gaebaljip.exceed.screens
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+
+@Composable
+fun FoodScreen() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+    ) {
+        Text(
+            text = "Food",
+            style = MaterialTheme.typography.bodyLarge,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.align(Alignment.Center)
+        )
+    }
+}

--- a/AOS/app/src/main/java/com/gaebaljip/exceed/screens/HomeScreen.kt
+++ b/AOS/app/src/main/java/com/gaebaljip/exceed/screens/HomeScreen.kt
@@ -1,0 +1,23 @@
+package com.gaebaljip.exceed.screens
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+
+@Composable
+fun HomeScreen() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+    ) {
+        Text(
+            text = "Home",
+            textAlign = TextAlign.Center,
+            modifier = Modifier.align(Alignment.Center)
+        )
+    }
+}

--- a/AOS/app/src/main/res/drawable/ic_add.xml
+++ b/AOS/app/src/main/res/drawable/ic_add.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M13,7h-2v4L7,11v2h4v4h2v-4h4v-2h-4L13,7zM12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.41,0 -8,-3.59 -8,-8s3.59,-8 8,-8 8,3.59 8,8 -3.59,8 -8,8z"/>
+</vector>

--- a/AOS/app/src/main/res/drawable/ic_alarm.xml
+++ b/AOS/app/src/main/res/drawable/ic_alarm.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M22,5.72l-4.6,-3.86 -1.29,1.53 4.6,3.86L22,5.72zM7.88,3.39L6.6,1.86 2,5.71l1.29,1.53 4.59,-3.85zM12.5,8L11,8v6l4.75,2.85 0.75,-1.23 -4,-2.37L12.5,8zM12,4c-4.97,0 -9,4.03 -9,9s4.02,9 9,9c4.97,0 9,-4.03 9,-9s-4.03,-9 -9,-9zM12,20c-3.87,0 -7,-3.13 -7,-7s3.13,-7 7,-7 7,3.13 7,7 -3.13,7 -7,7z"/>
+</vector>

--- a/AOS/app/src/main/res/drawable/ic_calendar.xml
+++ b/AOS/app/src/main/res/drawable/ic_calendar.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M19,4h-1V2h-2v2H8V2H6v2H5C3.89,4 3.01,4.9 3.01,6L3,20c0,1.1 0.89,2 2,2h14c1.1,0 2,-0.9 2,-2V6C21,4.9 20.1,4 19,4zM19,20H5V10h14V20zM9,14H7v-2h2V14zM13,14h-2v-2h2V14zM17,14h-2v-2h2V14zM9,18H7v-2h2V18zM13,18h-2v-2h2V18zM17,18h-2v-2h2V18z"/>
+</vector>

--- a/AOS/app/src/main/res/drawable/ic_food.xml
+++ b/AOS/app/src/main/res/drawable/ic_food.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M18.06,22.99h1.66c0.84,0 1.53,-0.64 1.63,-1.46L23,5.05h-5L18,1h-1.97v4.05h-4.97l0.3,2.34c1.71,0.47 3.31,1.32 4.27,2.26 1.44,1.42 2.43,2.89 2.43,5.29v8.05zM1,21.99L1,21h15.03v0.99c0,0.55 -0.45,1 -1.01,1L2.01,22.99c-0.56,0 -1.01,-0.45 -1.01,-1zM16.03,14.99c0,-8 -15.03,-8 -15.03,0h15.03zM1.02,17h15v2h-15z"/>
+</vector>

--- a/AOS/app/src/main/res/drawable/ic_home.xml
+++ b/AOS/app/src/main/res/drawable/ic_home.xml
@@ -1,0 +1,5 @@
+<vector android:height="24dp" android:tint="#000000"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@android:color/white" android:pathData="M10,20v-6h4v6h5v-8h3L12,3 2,12h3v8z"/>
+</vector>


### PR DESCRIPTION
## 📌 관련 이슈

close JNU-econovation/Gaebaljip#52

바텀 네비게이션 바 적용

## 🔑 주요 변경사항

- screens package에 Home, Calendar, Add, Food, Alarm 화면 생성
- 각 아이콘 파일 등록
- BottomNavItem 클래스 생성
- MainActivity에 적용