### PR TITLE
[AOS/feat] OnboardActivity 생성 및 Activity 전환 구현

### DIFF
--- a/AOS/app/src/main/AndroidManifest.xml
+++ b/AOS/app/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+    xmlns:tools="http://schemas.android.com/tools" >
 
     <application
         android:allowBackup="true"
@@ -11,17 +11,22 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Exceed"
-        tools:targetApi="31">
+        tools:targetApi="31" >
+        <activity
+            android:name=".OnboardActivity"
+            android:exported="true"
+            android:theme="@style/Theme.Exceed">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
         <activity
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"
-            android:theme="@style/Theme.Exceed">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-
-                <category android:name="android.intent.category.LAUNCHER" />
-            </intent-filter>
+            android:theme="@style/Theme.Exceed" >
         </activity>
     </application>
 

--- a/AOS/app/src/main/java/com/gaebaljip/exceed/OnboardActivity.kt
+++ b/AOS/app/src/main/java/com/gaebaljip/exceed/OnboardActivity.kt
@@ -1,0 +1,40 @@
+package com.gaebaljip.exceed
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.gaebaljip.exceed.screens.LoginScreen
+import com.gaebaljip.exceed.screens.OnboardingScreen
+import com.gaebaljip.exceed.ui.theme.ExceedTheme
+
+class OnboardActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        setContent {
+            val navController = rememberNavController()
+
+            NavHost(navController = navController, startDestination = "login") {
+                composable("login") {
+                    LoginScreen(navController)
+                }
+                composable("onboarding") {
+                    OnboardingScreen(navController)
+                }
+                composable("main") {
+                    MainScreenView()
+                }
+            }
+        }
+    }
+}

--- a/AOS/app/src/main/java/com/gaebaljip/exceed/screens/LoginScreen.kt
+++ b/AOS/app/src/main/java/com/gaebaljip/exceed/screens/LoginScreen.kt
@@ -12,10 +12,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
 
-@Preview(showBackground = true)
 @Composable
-fun LoginScreen() {
+fun LoginScreen(navController: NavController) {
     Row(
         modifier = Modifier
             .fillMaxSize()
@@ -23,9 +23,11 @@ fun LoginScreen() {
         verticalAlignment = Alignment.Bottom
     ) {
         Spacer(modifier = Modifier.weight(0.5f))
-        Button(onClick = { /*TODO*/ }, modifier = Modifier
+        Button(onClick = {
+                         navController.navigate("onboarding")
+        }, modifier = Modifier
             .padding(16.dp)
-            .width(130.dp)) {
+            .weight(3f)) {
             Text(text = "게스트 로그인")
         }
 
@@ -33,7 +35,7 @@ fun LoginScreen() {
 
         Button(onClick = { /*TODO*/ }, modifier = Modifier
             .padding(16.dp)
-            .width(130.dp)) {
+            .weight(3f)) {
             Text(text = "일반 로그인")
         }
         Spacer(modifier = Modifier.weight(0.5f))

--- a/AOS/app/src/main/java/com/gaebaljip/exceed/screens/OnboardingScreen.kt
+++ b/AOS/app/src/main/java/com/gaebaljip/exceed/screens/OnboardingScreen.kt
@@ -1,5 +1,8 @@
 package com.gaebaljip.exceed.screens
 
+import android.app.Activity
+import android.content.Intent
+import androidx.activity.OnBackPressedCallback
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -12,12 +15,14 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.KeyboardType
@@ -25,11 +30,14 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.core.app.ComponentActivity
+import androidx.navigation.NavController
+import androidx.navigation.NavHostController
+import com.gaebaljip.exceed.MainActivity
 import com.gaebaljip.exceed.ui.theme.pretendard
 
-@Preview(showBackground = true)
 @Composable
-fun OnboardingScreen() {
+fun OnboardingScreen(navController: NavController) {
 
     var heightInput by remember { mutableStateOf(TextFieldValue()) }
     var weightInput by remember { mutableStateOf(TextFieldValue()) }
@@ -122,15 +130,22 @@ fun OnboardingScreen() {
                 .padding(horizontal = 16.dp),
 
             )
-
         Button(
-            onClick = { /*TODO*/ }, modifier = Modifier
+            onClick = {
+                navController.navigate("main") {
+                    popUpTo(navController.graph.startDestinationId) {
+                        saveState = true
+                        inclusive = true
+                    }
+                    launchSingleTop = true
+                    restoreState = true
+                }
+            }, modifier = Modifier
                 .align(Alignment.End)
                 .padding(end = 16.dp, top = 16.dp)
         ) {
             Text(text = "완료")
         }
-
     }
 }
 

--- a/AOS/app/src/main/java/com/gaebaljip/exceed/screens/alarm/AlarmScreen.kt
+++ b/AOS/app/src/main/java/com/gaebaljip/exceed/screens/alarm/AlarmScreen.kt
@@ -419,7 +419,7 @@ fun TimePicker(
     modifier: Modifier,
     onChange: (Int) -> Unit
 ) {
-    val pagerState = rememberPagerState(initValue)
+    val pagerState = rememberPagerState(initialPage = initValue)
 
     LaunchedEffect(pagerState) {
         onChange(pagerState.currentPage)


### PR DESCRIPTION
## ⚠️ 관련 이슈
close #90 


## 📢 주요 변경사항

- OnboardActivity 생성
- 앱 시작 액티비티로 지정
- 로그인, 온보딩, 메인 화면 네비게이션 경로 설정
- 로그인 -> 온보딩 화면 이동 구현
- OnboardActivity -> MainActivity 이동 구현
- MainActivity로 이동 후, OnboardActivity 종료 기능 구현
